### PR TITLE
Close/Open reviews

### DIFF
--- a/Inspicio/Inspicio.csproj
+++ b/Inspicio/Inspicio.csproj
@@ -23,6 +23,7 @@
     <Content Include="wwwroot\css\JavaScript.js" />
     <Content Include="wwwroot\css\thumbs.js" />
     <Content Include="wwwroot\js\ajaxComments.js" />
+    <Content Include="wwwroot\js\ajaxOpenSlider.js" />
     <Content Include="wwwroot\js\filter.js" />
     <Content Include="wwwroot\js\pinComments.js" />
     <Content Include="wwwroot\js\ajaxThumbs.js" />
@@ -50,6 +51,7 @@
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup>
+    <Folder Include="Migrations\" />
     <Folder Include="Migrations\" />
     <Folder Include="Migrations\" />
     <Folder Include="Migrations\" />

--- a/Inspicio/Models/Image.cs
+++ b/Inspicio/Models/Image.cs
@@ -25,6 +25,9 @@ namespace Inspicio.Models
 
         public string Title { get; set; }
 
+        [DisplayName("Status")]
+        public bool OpenReview { get; set; }
+
         public ICollection<Comment>Comments { get; set; }
         public ICollection<Review> Reviews { get; set; }
 

--- a/Inspicio/Views/Images/Details.cshtml
+++ b/Inspicio/Views/Images/Details.cshtml
@@ -40,6 +40,12 @@
         <dd>
             @Html.DisplayFor(model => model.Title)
         </dd>
+        <dt>
+            @Html.DisplayNameFor(model => model.OpenReview)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.OpenReview)
+        </dd>
     </dl>
 </div>
 <div>

--- a/Inspicio/Views/Images/Index.cshtml
+++ b/Inspicio/Views/Images/Index.cshtml
@@ -37,6 +37,9 @@
             <th>
                 @Html.DisplayNameFor(model => model.NoOfDislikes)
             </th>
+            <th>
+                @Html.DisplayNameFor(model => model.OpenReview)
+            </th>
            
    
             <th>
@@ -76,6 +79,11 @@
             <td>
                 <a asp-action="View" asp-route-id="@item.ImageID">
                     @Html.DisplayFor(modelItem => item.NoOfDislikes)
+                </a>
+            </td>
+            <td>
+                <a asp-action="View" asp-route-id="@item.ImageID">
+                    @Html.DisplayFor(modelItem => item.OpenReview)
                 </a>
             </td>
             

--- a/Inspicio/Views/Images/View.cshtml
+++ b/Inspicio/Views/Images/View.cshtml
@@ -5,7 +5,7 @@
 
 <div class="view-container">
     <h2>@Model.Image.Title</h2>
-    <input type="checkbox" checked data-toggle="toggle" data-on="Open" data-off="Closed" data-onstyle="success" data-offstyle="danger">
+    <input type="checkbox" checked="@Model.Image.OpenReview" data-toggle="toggle" data-on="Open" data-off="Closed" data-onstyle="success" data-offstyle="danger" id="toggle">
     <hr />
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
     <input id="ImageId" type="hidden" asp-for="@Model.Image.ImageID" />
@@ -113,6 +113,7 @@
 <script type="text/javascript" src="~/js/pinComments.js"></script>
 <script type="text/javascript" src="~/js/ajaxComments.js"></script>
 <script type="text/javascript" src="~/js/ajaxThumbs.js"></script>
+<script type="text/javascript" src="~/js/ajaxOpenSlider.js"></script>
 
 <script type="text/javascript" src="~/js/sidebar.js"></script>
 
@@ -126,7 +127,7 @@
     }
         $("#imageMap").width($("#image-container >img").width());
         $("#imageMap").height($("#image-container >img").height());
-    })
+    });
 </script>
 
 <link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">

--- a/Inspicio/Views/Images/View.cshtml
+++ b/Inspicio/Views/Images/View.cshtml
@@ -5,10 +5,12 @@
 
 <div class="view-container">
     <h2>@Model.Image.Title</h2>
+    <input type="checkbox" checked data-toggle="toggle" data-on="Open" data-off="Closed" data-onstyle="success" data-offstyle="danger">
     <hr />
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
     <input id="ImageId" type="hidden" asp-for="@Model.Image.ImageID" />
-
+  
+   
 
 
     <div class="img-wrapper">
@@ -42,7 +44,7 @@
                 <div class="row">
                     <button type="button" class="btn btn-info " onclick="popupState()">Hide markers</button>
                     <!--IF the image is created by the user--> <!--IF project is open-->
-                    <button class="btn btn-warning " type="submit">Close</button>
+                    <button class="btn btn-warning " type="submit">Close</button>              
                 </div>
             </div>
         </div>
@@ -126,3 +128,6 @@
         $("#imageMap").height($("#image-container >img").height());
     })
 </script>
+
+<link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">
+<script src="https://gitcdn.github.io/bootstrap-toggle/2.2.2/js/bootstrap-toggle.min.js"></script>

--- a/Inspicio/wwwroot/js/ajaxOpenSlider.js
+++ b/Inspicio/wwwroot/js/ajaxOpenSlider.js
@@ -1,0 +1,31 @@
+﻿
+$(function () {
+    $('#toggle').bootstrapToggle({
+        on: 'Open',
+        off: 'Closed'
+    });
+})
+
+
+$(function () {
+    $('#toggle').change(function () {
+        var DataFromToggle = {
+
+        "ImageId": $("#ImageId").val(),
+        "Open": $("#toggle").prop('checked')
+        }
+
+        $.ajax(
+        {
+            type: "POST", //HTTP POST Method  
+            url: "../CloseReview", // Controller/View  
+            contentType: "application/json;",
+            dataType: "text",
+            data: JSON.stringify(DataFromToggle),
+
+
+            success: function () {
+            }
+        });
+    })
+})


### PR DESCRIPTION
A toggle has been added to allow users to close and open reviews. The database records whether a review is open or closed based on the toggle position. The design of this page will be changed, so mostly interested in the functionality. 

Expectations:
If toggle is in off position, the review is closed (shown in DB data).
If toggle is in on position, the review is open (shown in DB data).
The position of the toggle is saved, and if the user leaves the page and returns again, it should be in the same state they left it.
The view all page indicates which reviews are open/closed using checkboxes. 