### PR TITLE
Non root url

### DIFF
--- a/Inspicio/Startup.cs
+++ b/Inspicio/Startup.cs
@@ -72,6 +72,12 @@ namespace Inspicio
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
             loggerFactory.AddDebug();
 
+            var basePath = Configuration.GetValue("InspicioBasePath", defaultValue: string.Empty);
+            if (!string.IsNullOrWhiteSpace(basePath))
+            {
+                app.UsePathBase(basePath);
+            }
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/Inspicio/Startup.cs
+++ b/Inspicio/Startup.cs
@@ -24,7 +24,8 @@ namespace Inspicio
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
                 .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                .AddEnvironmentVariables();
 
             if (env.IsDevelopment())
             {


### PR DESCRIPTION
This lets you set the DB connection string and base URL via the environment variables, to allow for publishing to http://test-server/branch-name and have the `asp-route` stuff build the correct urls.

There might still be some places that have a hard coded `src="/something"` in some html somewhere, but I'm, not addressing those in this pull request.