### PR TITLE
#70  review state switching on navigation

### DIFF
--- a/Inspicio/Views/Shared/_Layout.cshtml
+++ b/Inspicio/Views/Shared/_Layout.cshtml
@@ -38,6 +38,26 @@
     <script src="~/js/lity.js"></script>
 </head>
 <body>
+
+    <script>
+        /*
+         * The following is intentional, to force Chrome to run 
+         * this JS snippet after a history invoked back/forward navigation.
+         * Fixing the issue with Chrome using the BFCache, and displaying out-of-date content.
+         */
+        if (window.history.state != null && window.history.state.hasOwnProperty('historic')) {
+            if (window.history.state.historic == true) {
+                document.body.style.display = 'none';
+                window.history.replaceState({ historic: false }, '');
+                window.location.reload();
+            } else {
+                window.history.replaceState({ historic: true }, '');
+            }
+        } else {
+            window.history.replaceState({ historic: true }, '');
+        }
+    </script>
+
     <nav class="navbar navbar-inverse navbar-fixed-top">
         <div class="container">
             <div class="navbar-header">

--- a/Inspicio/Views/Shared/_Layout.cshtml
+++ b/Inspicio/Views/Shared/_Layout.cshtml
@@ -44,6 +44,7 @@
          * The following is intentional, to force Chrome to run 
          * this JS snippet after a history invoked back/forward navigation.
          * Fixing the issue with Chrome using the BFCache, and displaying out-of-date content.
+         * https://stackoverflow.com/questions/9071838/force-reload-refresh-when-pressing-the-back-button
          */
         if (window.history.state != null && window.history.state.hasOwnProperty('historic')) {
             if (window.history.state.historic == true) {


### PR DESCRIPTION
Fix issue relating the bfcache and chrome navigation.

Chrome uses the bfcache for faster load times, but as a result was displaying incorrect data as the cache was from before any ajax and/or js had been executed fully.

This fix forces a page refresh for any other time than the first time a page is visited, without displaying the old content first. It may or may not be a good idea to relocate this to individually pages, instead of all the pages as a result of 'pushing' it in the _Layout.cshtml file.

Please test on more than just chrome.